### PR TITLE
Fix the potential pthread problem on Linux

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -7,4 +7,5 @@
 
 (declare-native
     :name "sqlite3"
+    :cflags ["-pthread"]
     :source @["sqlite3.c" "main.c"])


### PR DESCRIPTION
Without this flag, the sqlite3 library emits a lot of warnings when compiling. Also, when I am trying to import it after the build, it errors with: `undefined symbol pthread_mutexattr_settype`. 

On SO I found this solution for C, and indeed it works. But I tested it only on my Arch Linux based desktop. Later I can check it on macOS, and maybe on Windows, but this PR is mostly heads-up as my C-fu is also pretty limited.