### PR TITLE
BREAKING: Make column names keywords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ janet:3:> (sql/eval db `CREATE TABLE customers(id INTEGER PRIMARY KEY, name TEXT
 janet:4:> (sql/eval db `INSERT INTO customers VALUES(:id, :name);` {:name "John" :id 12345})
 @[]
 janet:5:> (sql/eval db `SELECT * FROM customers;`)
-@[{"id" 12345 "name" "John"}]
+@[{:id 12345 :name "John"}]
 ```
 
 Finally, close the database connection when done with it.

--- a/main.c
+++ b/main.c
@@ -223,7 +223,7 @@ static const char *execute_collect(sqlite3_stmt *stmt, JanetArray *rows) {
     /* Get column names */
     Janet *tupstart = janet_tuple_begin(ncol);
     for (int i = 0; i < ncol; i++) {
-        tupstart[i] = janet_cstringv(sqlite3_column_name(stmt, i));
+        tupstart[i] = janet_ckeywordv(sqlite3_column_name(stmt, i));
     }
     const Janet *colnames = janet_tuple_end(tupstart);
 


### PR DESCRIPTION
The rationale is simply so the output of a query
can be fed directly back into another query without
first manually mapping 'keyword' on all keys in the table.