### PR TITLE
Boolean unwrapping fix

### DIFF
--- a/main.c
+++ b/main.c
@@ -108,7 +108,7 @@ static const char *bind1(sqlite3_stmt *stmt, int index, Janet value) {
             res = sqlite3_bind_null(stmt, index);
             break;
         case JANET_BOOLEAN:
-            res = sqlite3_bind_int(stmt, index, janet_unwrap_integer(value));
+            res = sqlite3_bind_int(stmt, index, janet_unwrap_boolean(value));
             break;
         case JANET_NUMBER:
             res = sqlite3_bind_double(stmt, index, janet_unwrap_number(value));

--- a/test/test.janet
+++ b/test/test.janet
@@ -8,20 +8,20 @@
   (if (not c) (error "failed assertion")))
 (def db (sql/open "build/test.db"))
 (try (sql/eval db `DROP TABLE people`) ([_]))
-(sql/eval db `CREATE TABLE people(name TEXT, age INTEGER);`)
-(sql/eval db `INSERT INTO people values(:name, :age)` {:name "John" :age 20})
-(sql/eval db `INSERT INTO people values(:name, :age)` {:name "Paul" :age 30})
-(sql/eval db `INSERT INTO people values(:name, :age)` {:name "Bob" :age 40})
-(sql/eval db `INSERT INTO people values(:name, :age)` {:name "Joe" :age 50})
+(sql/eval db `CREATE TABLE people(name TEXT, age INTEGER, bool INTEGER);`)
+(sql/eval db `INSERT INTO people values(:name, :age, :bool)` {:name "John" :age 20 :bool false})
+(sql/eval db `INSERT INTO people values(:name, :age, :bool)` {:name "Paul" :age 30 :bool true})
+(sql/eval db `INSERT INTO people values(:name, :age, :bool)` {:name "Bob" :age 40 :bool false})
+(sql/eval db `INSERT INTO people values(:name, :age, :bool)` {:name "Joe" :age 50 :bool true})
 (def results (sql/eval db `SELECT * FROM people`))
 (assert (= (length results) 4))
 
 (def update-result
   (-> (sql/eval db
-                `UPDATE people set name = :new_name where name = :old_name RETURNING name, age`
+                `UPDATE people set name = :new_name where name = :old_name RETURNING name, age, bool`
                 {:new_name "Harry" :old_name "Paul"})
       (first)))
-(assert (= update-result {:name "Harry" :age 30}))
+(assert (= update-result {:name "Harry" :age 30 :bool 1}))
 
 
 (sql/close db)


### PR DESCRIPTION
Booleans are unwrapped with `janet_unwrap_integer`, which for some reason results in a value of `-2,147,483,648` (upper 32 bits set.) Testing on three separate amd64 systems, swapping this out for `janet_unwrap_boolean` fixes the issue. Also added a bool test just in case. Closes #25 

Janet 1.35.2, 1.36.0-dev
openbsd 7.4 - NUC, celeron 847
windows 10 - i7-8700
ubuntu 22.04 lxc - proxmox, i5-8500